### PR TITLE
Create private constructor

### DIFF
--- a/lib/src/cmd_plus.dart
+++ b/lib/src/cmd_plus.dart
@@ -6,6 +6,9 @@ import 'dart:io';
 /// log errors and process results.
 /// {@endtemplate}
 class CmdPlus {
+  /// Default private constructor to avoid confusing user.
+  const CmdPlus._();
+
   /// {@template cli_run}
   /// {@macro cli}
   ///


### PR DESCRIPTION
So that the user of the package won't create a `CmdPlus` variable like `final cmd = CmdPlus()`.