### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.4
 
 - Removes DCM dependencies
+- Updates dependencies
 
 ## 1.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # cmd_plus changelog
 
+## 1.3.4
+
+- Removes DCM dependencies
+
 ## 1.3.3
 
 - Updates documentation

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.0.5 <4.0.0'
 
 dependencies:
-  freezed: ^2.3.2
-  freezed_annotation: ^2.2.0
+  freezed: ^3.0.0
+  freezed_annotation: ^3.0.0
   io: ^1.0.4
   mason_logger: ^0.3.0
   path: ^1.8.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
-  dart_code_metrics: any
-  mankeli_analysis: ^1.1.0
+  mankeli_analysis: ^1.1.2
   mocktail: ^0.3.0
 
 scripts:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.3.3
   mankeli_analysis: ^1.1.2
-  mocktail: ^0.3.0
+  mocktail: ^1.0.0
 
 scripts:
   gen:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   freezed: ^2.3.2
   freezed_annotation: ^2.2.0
   io: ^1.0.4
-  mason_logger: ^0.2.5
+  mason_logger: ^0.3.0
   path: ^1.8.2
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cmd_plus
 description: A wrapper around dart:io Process, package:io and mason_logger to
   make it easier to run commands in dart scripts.
-version: 1.3.3
+version: 1.3.4
 homepage: https://mankeli.co
 repository: https://github.com/Mankeli-Software/cmd_plus
 issue_tracker: https://github.com/Mankeli-Software/cmd_plus/issues


### PR DESCRIPTION
## Description

Fixes #9 

1) Updated `mason_logger` to `^0.3.0`
2) Updated `freezed` & `freezed_annotation` dependencies to `^3.0.0`
3) Updated `mocktail` dependency to `^1.0.0`
4) Removed dependency on dart code metrics

## Conventional Type

Pretty similar in spirit to the recently merged https://github.com/Mankeli-Software/mankeli_core/pull/2/

- [ ] ✨ feat
- [ ] 🛠️ fix
- [x] ✅ chore
- [ ] 📝 doc
- [ ] 🧪 test
- [ ] ❌ BREAKING CHANGE
